### PR TITLE
Update YAML to use the Shell syntax instead of C

### DIFF
--- a/src/languages.rs
+++ b/src/languages.rs
@@ -48,7 +48,7 @@ const SYNTAXES: [(&str, &[SyntaxRule]); 15] = [
     ("shell", &SHELL),
     ("toml", &C),
     ("typescript", &C),
-    ("yaml", &C),
+    ("yaml", &SHELL),
 ];
 
 /// Given a language name, get [syntax rules] for a predefined


### PR DESCRIPTION
YAML only supports a single # line comment, and no multi-line. It's rules are a little be more complex, but it's similar to shell than C.

Fixes https://github.com/vallentin/comment-parser/issues/4